### PR TITLE
Add API Transport Spec: Instrumentation, LLM Prompts, and Stack

### DIFF
--- a/projects/04-elixir-realtime-game-platform/01-api-transport/INSTRUMENTATION.md
+++ b/projects/04-elixir-realtime-game-platform/01-api-transport/INSTRUMENTATION.md
@@ -1,0 +1,35 @@
+# Transport Instrumentation Plan
+
+## Metrics (Prometheus Names)
+- `transport_session_active_total` (gauge): active sessions by transport (`transport="ws|rest|mailbox"`).
+- `transport_mailbox_messages_queued` (gauge): queued messages per mailbox; emits high-water mark histogram.
+- `transport_mailbox_enqueue_total` (counter): messages enqueued; labels `source="router|system"`.
+- `transport_mailbox_delivery_total` (counter): messages delivered; labels `transport`.
+- `transport_mailbox_drop_total` (counter): drops due to TTL expiry or overflow (`reason="ttl|overflow|transport-closed"`).
+- `transport_inbound_actions_total` (counter): actions received per transport + action type.
+- `transport_outbound_payload_bytes` (histogram): serialized payload size for sends.
+- `transport_dispatch_latency_ms` (histogram): end-to-end action dispatch latency (receive → worker response).
+- `transport_poll_duration_ms` (histogram): REST long-poll duration; expect plateau near timeout.
+- `transport_rate_limit_trigger_total` (counter): rate limit hits by transport + IP bucket.
+
+## Logs
+- Structured JSON logs via `Phoenix.LoggerJSON`; include `session_id`, `transport`, `trace_id`, `message_type`.
+- Log levels: `info` for connect/disconnect, `debug` for payload traces (disabled in prod), `warn` for drops/rate limit.
+
+## Traces
+- Leverage `opentelemetry_phoenix` to span request lifecycle.
+- Custom spans:
+  - `Transport.Router.handle_action/3`
+  - `Transport.Mailbox.fetch/2`
+  - `Transport.Mailbox.deliver/2`
+- Inject trace context into outbound messages so worker pipeline can continue spans.
+
+## Alerts & SLOs
+- 99p WebSocket latency < 150 ms.
+- REST poll success rate ≥ 99%.
+- Mailbox drop ratio < 0.1% of deliveries per hour.
+- Raise alert when `transport_session_active_total{transport="mailbox"}` > configured capacity or `transport_rate_limit_trigger_total` spikes > baseline.
+
+## Instrumentation Backlog
+- Write Telemetry handlers publishing metrics via `PromEx` and StatsD.
+- Add integration tests asserting telemetry events fire for session open/close and mailbox drops.

--- a/projects/04-elixir-realtime-game-platform/01-api-transport/LLM_PROMPTS.md
+++ b/projects/04-elixir-realtime-game-platform/01-api-transport/LLM_PROMPTS.md
@@ -1,0 +1,40 @@
+# Suggested LLM Prompts
+
+## Implement Transport Session Manager
+```
+You are pairing on the Elixir `TransportSessionManager` (`lib/game_platform/transport/session_manager.ex`). 
+Goal: supervise multi-transport sessions (WebSocket, REST, mailbox) with shared state, TTL, and keepalives.
+Deliver:
+- `start_link/1`, `init/1` with ETS table bootstrap.
+- APIs: `open_session(opts)`, `get(session_id)`, `touch(session_id, metadata)`, `expire_idle()`.
+- Enforce configurable TTL (minutes) and max mailbox depth.
+- Emit `[:transport, :session, :open|:touch|:expire]` telemetry events.
+Follow configurations from `config/runtime.exs`: `:session_ttl_minutes`, `:max_mailbox_messages`.
+Return code only; no commentary.
+```
+
+## Build REST Long-Poll Controller Test
+```
+Context: Phoenix controller `RestPollController` handling GET `/poll/:session_id`.
+Write an ExUnit test module under `test/game_platform/transport/rest_poll_controller_test.exs` that:
+1. boots the Phoenix endpoint,
+2. seeds the `MailboxStore` with messages,
+3. simulates GET with `since` cursor and asserts streamed JSON payload + reconnection hints,
+4. covers timeout path (30s default) using `@endpoint` configuration.
+Include setup blocks, use `Phoenix.ConnTest`, and assert telemetry events captured via `with_telemetry_events`.
+```
+
+## Instrument Mailbox Store
+```
+We need telemetry + metrics for `MailboxStore`.
+Add instrumentation emitting `[:transport, :mailbox, :enqueue]`, `[:transport, :mailbox, :deliver]`, `[:transport, :mailbox, :drop]`.
+Ensure ETS counters updated atomically.
+Document metric names and units in `instrumentation.md`.
+```
+
+## Load Test Script Outline
+```
+Draft a k6 script template that stresses REST polling at 200 rps, with jittered long-poll durations.
+Include setup to fetch auth token, scenario for message fetch, and thresholds for latency.
+Reference transport endpoints: `/actions/:session_id`, `/poll/:session_id`.
+```

--- a/projects/04-elixir-realtime-game-platform/01-api-transport/README.md
+++ b/projects/04-elixir-realtime-game-platform/01-api-transport/README.md
@@ -1,0 +1,54 @@
+# API Transport Subproject
+
+## Goal & Problem
+- Deliver multi-transport client connectivity (Phoenix Channels, REST long-poll, curl mailbox) that routes game actions and world updates with <50 ms median latency and deterministic ordering.
+- Remove superfluous serialization hops between transports and simulation workers while enforcing session security for both authenticated and scriptable clients.
+
+## Scope & Deliverables
+- Production-ready transport surface for WebSocket, REST, and mailbox clients with shared session contracts.
+- Configurable session lifecycle, rate limits, and retention policies surfaced in Phoenix config.
+- Transport telemetry + trace propagation compatible with platform-wide observability (metrics, logs, traces).
+- Migration-ready documentation for hand-off to implementation team and external API consumers.
+
+## Key Decisions & Constraints
+- Phoenix app stays single Phoenix.Endpoint; transports plug into Endpoint router/channels.
+- Authentication undecided (QUESTIONS.md #4); design assumes pluggable token verifier that can be swapped without invasive rewrites.
+- Session expiration windows, mailbox retention, and polling timeout unresolved (QUESTIONS.md #1-3); note the touchpoints in components below.
+- CLI mailbox must tolerate offline workflows: server queues outbound messages until TTL or explicit ACK.
+- Transport layer emits telemetry events on every send/receive for back-pressure visibility.
+
+## Code Components To Build
+- `lib/game_platform/transport/application.ex`: supervision tree mounting routers, channels, and background workers.
+- `TransportSessionManager` (`GenServer`): owns session registry, transport-agnostic metadata, TTL enforcement, token validation hooks, keepalive timers.
+- `TransportIdGenerator`: monotonic ID generator (ULID/UUIDv7) to avoid collisions across transports.
+- `ChannelGateway` (`Phoenix.Channel`): handshake, presence sync, fast-path outbound diff streaming, flow control (throttled push).
+- `RestPollController` (`Phoenix.Controller`): long-poll GET `/poll/:session_id`, streaming responses via `Plug.Conn.send_chunked`, handles timeout negotiation and reconnection hints.
+- `RestActionController`: POST `/actions/:session_id`, validates payload, enqueues into router, returns ACK/next-poll hints.
+- `MailboxController`: GET `/mailbox/:id/messages` + POST `/mailbox/:id/actions`, wraps queue cursor & delivery semantics, supports `since` param for incremental fetch, enforces max queue length.
+- `MailboxStore` (`ETS` backed): per-session message queues with TTL, ack tracking, optional compression for bulk payloads.
+- `MessageRouter` (`GenServer` or `Broadway` pipeline): normalizes inbound messages, dispatches to simulation, fans out responses to correct transport, enforces ordering guarantees.
+- `TransportCodec`: shared encode/decode layer (Erlang term binary for internal, JSON/protobuf for clients) with schema versioning.
+- `TransportRateLimiter`: pluggable (default `ExRated`) guard to prevent DoS across transports.
+- `TransportTelemetry`: instrumentation module emitting `[:transport, :receive]`, `[:transport, :send]`, `[:transport, :drop]` events (metrics/traces).
+- `TransportBackpressureSupervisor`: monitors queue depth, triggers load-shedding strategies (drop oldest mailbox messages, pause polling).
+
+## Flows To Instrument/Test
+- Session creation via each transport (WS connect handshake, REST auth, mailbox activation) → expect consistent session IDs + metadata.
+- Message dispatch path: client action → router → worker dispatch → response broadcast; verify ordering, latency, error propagation.
+- Mailbox fetch cycles: message enqueue, fetch with ACK, TTL expiry, overflow eviction.
+- REST long-poll reconnect: client timeout, resume with `since` cursor, ensure idempotent responses.
+- Backpressure scenarios: artificially fill outbound queues, confirm rate limiter + load shedding triggers telemetry and protective behavior.
+- Transport failover: upgrade from REST to WebSocket mid-session without losing state (session manager migration path).
+- Observability: ensure telemetry events surface metrics/traces/log correlation IDs per flow.
+
+## Artifacts To Produce (Next Contributors)
+- API contract doc (request/response schemas, error codes, pagination) once open questions #1-4 settle.
+- Session policy matrix covering TTL, keepalive cadence, auth requirements per transport.
+- Handbook entries for running transport-focused load tests and chaos drills.
+
+## Open Items Requiring Input
+- Message retention TTL & queue depth caps (QUESTIONS.md #1).
+- Default long-poll timeout + reconnection jitter (QUESTIONS.md #2).
+- Session inactivity timeout + keepalive cadence (QUESTIONS.md #3).
+- Authentication strategy (token-based vs unauthenticated with rate limits) (QUESTIONS.md #4).
+

--- a/projects/04-elixir-realtime-game-platform/01-api-transport/STACK.md
+++ b/projects/04-elixir-realtime-game-platform/01-api-transport/STACK.md
@@ -1,0 +1,43 @@
+# Library & Framework Notes
+
+## Core Phoenix Stack
+- **Phoenix 1.7 Channels**: Native WebSocket transport, presence, intercepts. Use `Phoenix.Socket.Transport` for custom protocol tweaks.
+- **Bandit** (preferred HTTP adapter): Unified HTTP/1.1 + HTTP/2 + WebSocket, async responses friendly to long-polling.
+- **Plug.Telemetry** + **Phoenix.LoggerJSON**: Structured request logs + correlation IDs across transports.
+
+## Session & Routing Helpers
+- **Phoenix.Token**: HMAC-signed tokens for session bootstrap; configurable max age matches TTL decisions (#1-3).
+- **NimbleOptions**: Validate transport config (timeouts, limits) at compile time.
+- **Registry** or **Horde**: Distributed process registry for session manager (choose once multiplayer footprint defined).
+
+## Rate Limiting & Abuse Prevention
+- **ExRated** (ETS counter buckets) or **Hammer**: minimal dependencies, token bucket semantics; plug into controllers/channels.
+- **Req/Slib** optional: enforce IP-based bans if anonymous mailbox allowed.
+
+## Queue & State Storage
+- **ETS** + **:persistent_term** for mailbox queues and session metadata; leverage `:ets.update_counter` for metrics.
+- **Cachex** alternative if eviction policies need richer callbacks.
+
+## Serialization
+- **Jason**: JSON encoding for REST/mailbox.
+- **protobuf-elixir** or **msgpax** (MessagePack) if binary framing desired for bandwidth-sensitive clients.
+- **:erlang.term_to_binary** reserved for internal Router ↔ Worker payloads.
+
+## Observability
+- **Telemetry.Metrics**, **TelemetryPoller**: feed metrics into Prometheus via **prom_ex** or StatsD via **telemetry_metrics_statsd**.
+- **OpenTelemetry** instrumentation (`opentelemetry_telemetry`, `opentelemetry_phoenix`) for trace propagation.
+- **LoggerFileBackend** (optional) for request audit logs.
+
+## Testing & Tooling
+- **Mox** for mocking worker interfaces during transport tests.
+- **Wallaby** or **Playwright** (external) for full-stack transport validation (WS + REST).
+- **k6** or **Vegeta** for load testing (document scripts under `/ops/load-tests` later).
+
+## CLI Mailbox Support
+- **Finch** for server-initiated HTTP clients if we need to push webhooks/notifications.
+- **Plug.Parsers** configuration ensuring large JSON payloads handled without DOS.
+- **Erlang :queue** for per-session message buffers if ETS not enough; pair with `:gb_sets` for deduplication.
+
+## Future Options To Monitor
+- **Livebook Smart Cells** for interactive transport debugging.
+- **Nebulex** if distributed cache required once scaling to multiple nodes.


### PR DESCRIPTION
## Summary
Adds foundational API Transport specifications for multi-transport sessions (WebSocket, REST long-polling, and mailbox) by introducing instrumentation, LLM prompts to guide implementation, and architectural notes. These docs establish observability, prompts-driven development, and stack choices to accelerate implementation.

## Files Added
- INSTRUMENTATION.md: Transport instrumentation plan outlining metrics, logs, traces, alerts, and backlog.
- LLM_PROMPTS.md: Suggested prompts to implement TransportSessionManager, REST long-poll tests, and mailbox instrumentation.
- README.md: High-level goals, scope, decisions, and components for the API transport subproject.
- STACK.md: Library and framework notes for core transport stack, observability, storage, serialization, testing, and tooling.

## How this helps
- Aligns telemetry, tracing, and logging expectations across transports.
- Provides concrete prompts to drive implementation tasks and keep artifacts aligned with goals.
- Documents stack decisions to ensure consistent tooling and integration.

## Next steps
- Use the prompts to implement the TransportSessionManager, controllers, and mailbox subsystem.
- Flesh out integration tests for telemetry events and traces.
- Expand documentation with API contracts and load-test plans in follow-up PRs.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/05bca5fc-38f6-4119-8aee-c2ac83799d12